### PR TITLE
Add IgnoreSelf option

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -10,6 +10,7 @@
 
     "ACTIVEAURAS.FORM_IsAura" : "Effect is Aura",
     "ACTIVEAURAS.FORM_Inactive": "Apply while inactive",
+    "ACTIVEAURAS.FORM_IgnoreSelf": "Ignore self",
     "ACTIVEAURAS.FORM_Hidden":"Disable while hidden",
     "ACTIVEAURAS.FORM_TargetsName":"Aura Targets",
     "ACTIVEAURAS.FORM_TargetsNone":"None",
@@ -19,7 +20,7 @@
     "ACTIVEAURAS.FORM_Radius": "Aura radius",
     "ACTIVEAURAS.FORM_Height": "Check Token Height",
 
-    "ACTIVEAURAS.ApplyLog":"Active Auras: applied {effectDataLabel} to {tokenName}",
-    "ACTIVEAURAS.RemoveLog":"Active Auras: removed {effectDataLabel} to {tokenName}"
-
+    "ACTIVEAURAS.ApplyLog":"ActiveAuras | Applied '{effectDataLabel}' to {tokenName}",
+    "ACTIVEAURAS.RemoveLog":"ActiveAuras | Removed '{effectDataLabel}' from {tokenName}",
+    "ACTIVEAURAS.IgnoreSelfLog":"ActiveAuras | Ignoring '{effectDataLabel}' change {changeKey} to {actorName}"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -10,6 +10,7 @@
 
     "ACTIVEAURAS.FORM_IsAura" : "Efecto es aura",
     "ACTIVEAURAS.FORM_Inactive": "Aplicar mientras esté inactivo",
+    "ACTIVEAURAS.FORM_IgnoreSelf": "Ignorarse a sí mismo",
     "ACTIVEAURAS.FORM_Hidden":"Desactivar mientras esté oculto",
     "ACTIVEAURAS.FORM_TargetsName":"Objetivos del aura",
     "ACTIVEAURAS.FORM_TargetsNone":"Ninguno",
@@ -19,7 +20,7 @@
     "ACTIVEAURAS.FORM_Radius": "Radio del aura",
     "ACTIVEAURAS.FORM_Height": "Comprobar altura del token",
 
-    "ACTIVEAURAS.ApplyLog":"Active Auras: {effectDataLabel} aplicado a {tokenName}",
-    "ACTIVEAURAS.RemoveLog":"Active Auras: {effectDataLabel} quitado de {tokenName}"
-
+    "ACTIVEAURAS.ApplyLog":"ActiveAuras | '{effectDataLabel}' aplicado a {tokenName}",
+    "ACTIVEAURAS.RemoveLog":"ActiveAuras | '{effectDataLabel}' quitado de {tokenName}",
+    "ACTIVEAURAS.IgnoreSelfLog":"ActiveAuras | Igrnorando '{effectDataLabel}' cambiar {changeKey} a {actorName}"
 }

--- a/src/aura.js
+++ b/src/aura.js
@@ -47,6 +47,7 @@ Hooks.on("ready", () => {
 
         const FormIsAura = game.i18n.format("ACTIVEAURAS.FORM_IsAura");
         const FormInactive = game.i18n.format("ACTIVEAURAS.FORM_Inactive");
+        const FormIgnoreSelf = game.i18n.format("ACTIVEAURAS.FORM_IgnoreSelf");
         const FormHidden = game.i18n.format("ACTIVEAURAS.FORM_Hidden");
         const FormTargetsName = game.i18n.format("ACTIVEAURAS.FORM_TargetsName");
         const FormTargetsNone = game.i18n.format("ACTIVEAURAS.FORM_TargetsNone");
@@ -57,51 +58,50 @@ Hooks.on("ready", () => {
         const AuraTab = game.i18n.format("ACTIVEAURAS.tabname");
         const FormCheckHeight = game.i18n.format("ACTIVEAURAS.FORM_Height");
 
-        const tab = `<a class="item" data-tab="ActiveAuras">
-      <i class="fas fa-broadcast-tower"></i> ${AuraTab}
-    </a>`;
+        const tab = `<a class="item" data-tab="ActiveAuras"><i class="fas fa-broadcast-tower"></i> ${AuraTab}</a>`;
 
         const contents = `
         <div class="tab" data-tab="ActiveAuras">
             <div class="form-group">
                 <label>${FormIsAura}?</label>
-                <input name="flags.${MODULE_NAME}.isAura" type="checkbox" ${flags[MODULE_NAME].isAura ? 'checked' : ''} </input>
+                <input name="flags.${MODULE_NAME}.isAura" type="checkbox" ${flags[MODULE_NAME].isAura ? 'checked' : ''}></input>
              </div>
-        <div class="form-group">
-            <label>${FormInactive}?</label>
-            <input name="flags.${MODULE_NAME}.inactive" type="checkbox" ${flags[MODULE_NAME].inactive ? 'checked' : ''} </input>
-        </div>
-        <div class="form-group">
-            <label>${FormHidden}?</label>
-            <input name="flags.${MODULE_NAME}.hidden" type="checkbox" ${flags[MODULE_NAME].hidden ? 'checked' : ''} </input>
-        </div>
-        <div class="form-group">
-            <label>${FormCheckHeight}</label>
-            <input name="flags.${MODULE_NAME}.height" type="checkbox" ${flags[MODULE_NAME].height ? 'checked' : ''} </input>
-         </select>
-        </div>
-        <div class="form-group">
-            <label>${FormTargetsName}:</label>
-            <select name="flags.${MODULE_NAME}.aura" data-dtype="String" value=${flags[MODULE_NAME]?.aura}>
-                <option value="None" ${flags[MODULE_NAME].aura === 'None' ? 'selected' : ''}></option>
-                <option value="Enemy"${flags[MODULE_NAME].aura === 'Enemy' ? 'selected' : ''}>${FormTargetsEnemy}</option>
-                <option value="Allies"${flags[MODULE_NAME].aura === 'Allies' ? 'selected' : ''}>${FormTargetsAllies}</option>
-                <option value="All"${flags[MODULE_NAME].aura === 'All' ? 'selected' : ''}>${FormTargetsAll}</option>
-            </select>
-        </div>
-        <div class="form-group">
-            <label>${FormRadius}</label>
-            <input id="radius" name="flags.${MODULE_NAME}.radius" type="number" min="0" value="${flags[MODULE_NAME].radius}"></input>
-         </select>
-        </div>
-        
-    </div>`;
+             <div class="form-group">
+                <label>${FormIgnoreSelf}?</label>
+                <input name="flags.${MODULE_NAME}.ignoreSelf" type="checkbox" ${flags[MODULE_NAME].ignoreSelf ? 'checked' : ''}></input>
+            </div>
+            <div class="form-group">
+                <label>${FormInactive}?</label>
+                <input name="flags.${MODULE_NAME}.inactive" type="checkbox" ${flags[MODULE_NAME].inactive ? 'checked' : ''}></input>
+            </div>
+            <div class="form-group">
+                <label>${FormHidden}?</label>
+                <input name="flags.${MODULE_NAME}.hidden" type="checkbox" ${flags[MODULE_NAME].hidden ? 'checked' : ''}></input>
+            </div>
+            <div class="form-group">
+                <label>${FormCheckHeight}</label>
+                <input name="flags.${MODULE_NAME}.height" type="checkbox" ${flags[MODULE_NAME].height ? 'checked' : ''}></input>
+            </div>
+            <div class="form-group">
+                <label>${FormTargetsName}:</label>
+                <select name="flags.${MODULE_NAME}.aura" data-dtype="String" value=${flags[MODULE_NAME]?.aura}>
+                    <option value="None" ${flags[MODULE_NAME].aura === 'None' ? 'selected' : ''}></option>
+                    <option value="Enemy"${flags[MODULE_NAME].aura === 'Enemy' ? 'selected' : ''}>${FormTargetsEnemy}</option>
+                    <option value="Allies"${flags[MODULE_NAME].aura === 'Allies' ? 'selected' : ''}>${FormTargetsAllies}</option>
+                    <option value="All"${flags[MODULE_NAME].aura === 'All' ? 'selected' : ''}>${FormTargetsAll}</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label>${FormRadius}</label>
+                <input id="radius" name="flags.${MODULE_NAME}.radius" type="number" min="0" value="${flags[MODULE_NAME].radius}"></input>
+            </div> 
+        </div>`;
+
         html.find(".tabs .item").last().after(tab);
         html.find(".tab").last().after(contents);
     });
 
     let AuraMap = new Map()
-
 
     /**
      * Re-run aura detection on token creation
@@ -177,14 +177,6 @@ Hooks.on("ready", () => {
             CollateAuras(canvas, true, false)
         }, 20)
     })
-
-    function ActiveAurasApply(actor, change) {
-        if (actor._id == change.effect.data.origin.split('.')[1] && change.effect.data.flags?.ActiveAuras?.ignoreSelf) {
-            console.log(`ActiveAuras | Ignoring '${change.effect.data.label}' change ${change.key} to ${actor.name}`);
-            return null;
-        }
-        return existingActiveEffectsApply.bind(this)(actor, change);
-    }
 
     function GetAllFlags(entity, scope) {
         {
@@ -463,6 +455,19 @@ Hooks.on("ready", () => {
 
             }
         }
+    }
+
+    /**
+     * 
+     * @param {Actor} actor 
+     * @param {ActiveEffect} change 
+     */
+    function ActiveAurasApply(actor, change) {
+        if (actor._id == change.effect.data.origin?.split('.')[1] && change.effect.data.flags?.ActiveAuras?.ignoreSelf) {
+            console.log(game.i18n.format("ACTIVEAURAS.IgnoreSelfLog", { effectDataLabel: change.effect.data.label, changeKey: change.key, actorName: actor.name }));
+            return null;
+        }
+        return existingActiveEffectsApply.bind(this)(actor, change);
     }
 
     CollateAuras(canvas, true, false)

--- a/src/aura.js
+++ b/src/aura.js
@@ -40,10 +40,7 @@ Hooks.on("ready", () => {
      * Hooks onto effect sheet to add aura configuration
      */
     Hooks.on("renderActiveEffectConfig", async (sheet, html) => {
-        if(!sheet.object.data.flags?.ActiveAuras?.aura) {
-            await sheet.object.setFlag(`${MODULE_NAME}`, 'aura')
-        }
-        const flags = sheet.object.data.flags;
+        const flags = sheet.object.data.flags ?? {};
 
         const FormIsAura = game.i18n.format("ACTIVEAURAS.FORM_IsAura");
         const FormInactive = game.i18n.format("ACTIVEAURAS.FORM_Inactive");
@@ -64,36 +61,36 @@ Hooks.on("ready", () => {
         <div class="tab" data-tab="ActiveAuras">
             <div class="form-group">
                 <label>${FormIsAura}?</label>
-                <input name="flags.${MODULE_NAME}.isAura" type="checkbox" ${flags[MODULE_NAME].isAura ? 'checked' : ''}></input>
+                <input name="flags.${MODULE_NAME}.isAura" type="checkbox" ${flags[MODULE_NAME]?.isAura ? 'checked' : ''}></input>
              </div>
              <div class="form-group">
                 <label>${FormIgnoreSelf}?</label>
-                <input name="flags.${MODULE_NAME}.ignoreSelf" type="checkbox" ${flags[MODULE_NAME].ignoreSelf ? 'checked' : ''}></input>
+                <input name="flags.${MODULE_NAME}.ignoreSelf" type="checkbox" ${flags[MODULE_NAME]?.ignoreSelf ? 'checked' : ''}></input>
             </div>
             <div class="form-group">
                 <label>${FormInactive}?</label>
-                <input name="flags.${MODULE_NAME}.inactive" type="checkbox" ${flags[MODULE_NAME].inactive ? 'checked' : ''}></input>
+                <input name="flags.${MODULE_NAME}.inactive" type="checkbox" ${flags[MODULE_NAME]?.inactive ? 'checked' : ''}></input>
             </div>
             <div class="form-group">
                 <label>${FormHidden}?</label>
-                <input name="flags.${MODULE_NAME}.hidden" type="checkbox" ${flags[MODULE_NAME].hidden ? 'checked' : ''}></input>
+                <input name="flags.${MODULE_NAME}.hidden" type="checkbox" ${flags[MODULE_NAME]?.hidden ? 'checked' : ''}></input>
             </div>
             <div class="form-group">
                 <label>${FormCheckHeight}</label>
-                <input name="flags.${MODULE_NAME}.height" type="checkbox" ${flags[MODULE_NAME].height ? 'checked' : ''}></input>
+                <input name="flags.${MODULE_NAME}.height" type="checkbox" ${flags[MODULE_NAME]?.height ? 'checked' : ''}></input>
             </div>
             <div class="form-group">
                 <label>${FormTargetsName}:</label>
                 <select name="flags.${MODULE_NAME}.aura" data-dtype="String" value=${flags[MODULE_NAME]?.aura}>
-                    <option value="None" ${flags[MODULE_NAME].aura === 'None' ? 'selected' : ''}></option>
-                    <option value="Enemy"${flags[MODULE_NAME].aura === 'Enemy' ? 'selected' : ''}>${FormTargetsEnemy}</option>
-                    <option value="Allies"${flags[MODULE_NAME].aura === 'Allies' ? 'selected' : ''}>${FormTargetsAllies}</option>
-                    <option value="All"${flags[MODULE_NAME].aura === 'All' ? 'selected' : ''}>${FormTargetsAll}</option>
+                    <option value="None" ${flags[MODULE_NAME]?.aura === 'None' ? 'selected' : ''}></option>
+                    <option value="Enemy"${flags[MODULE_NAME]?.aura === 'Enemy' ? 'selected' : ''}>${FormTargetsEnemy}</option>
+                    <option value="Allies"${flags[MODULE_NAME]?.aura === 'Allies' ? 'selected' : ''}>${FormTargetsAllies}</option>
+                    <option value="All"${flags[MODULE_NAME]?.aura === 'All' ? 'selected' : ''}>${FormTargetsAll}</option>
                 </select>
             </div>
             <div class="form-group">
                 <label>${FormRadius}</label>
-                <input id="radius" name="flags.${MODULE_NAME}.radius" type="number" min="0" value="${flags[MODULE_NAME].radius}"></input>
+                <input id="radius" name="flags.${MODULE_NAME}.radius" type="number" min="0" value="${flags[MODULE_NAME]?.radius}"></input>
             </div> 
         </div>`;
 


### PR DESCRIPTION
Add an 'ignoreSelf' flag that suppresses the ActiveEffect changes of an Aura on the source actor. This is different than the 'Apply while inactive?' flag; the ignoreSelf makes it clear that the aura is either active or inactive to others without deleting the effect on the bearer.

This is appropriate for debuffs and for times when the effect should not affect the bearer. (In my set up, the paladin's Aura of Protection was automatically applied the character via the system - not sure why, but the character was imported from DNDBeyond. Adding an aura with the same effect doubled the bonus, so I added this flag to avoid the duplication.)