### PR TITLE
fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
 ## 1.3.3
 - added filter for pre-update token to prevent non-effect updates triggering the main workflow
 - fixed CreateActiveEffect function that previously saved token ID to the aura map, rather than updating on a single applied token.
+
+## 1.3.35
+- Added debug setting to help with tracing errors
+- Added more debug arguments throughout the code to assist in debugging
+- Added check for auras in preDeleteToken before running the rest of the code
+- Reworked unlinked token checks to more accuratly remove auras when disabling auras or hiding the token
+- Reworked logic for removal of auras on active effect updates
+- Added support for item macros when DAE supports this
+- Cleaned up the code for removal of applied auras, this should prevent auras not applying/removing from tokens 

--- a/lang/en.json
+++ b/lang/en.json
@@ -3,6 +3,8 @@
     "ACTIVEAURAS.measurmentoptions_hint":"Use system defined movement measurement system rather than straight line (euclidean), default on",
     "ACTIVEAURAS.measurementHeight_name":"Height measurement system",
     "ACTIVEAURAS.measurementHeight_hint":"System for measuring heights in regards to auras. True is simple comparison of heights, false is eucleadian distance (experimental)",
+    "ACTIVEAURAS.debug_name" : "Debug",
+    "ACTIVEAURAS.debug_hint" : "Additional console logs for debugging steps",
     "ACTIVEAURAS.tabname": "Auras",
     
     "ACTIVEAURAS.walltoptions_name": "Walls Block Auras",

--- a/lang/es.json
+++ b/lang/es.json
@@ -3,6 +3,8 @@
     "ACTIVEAURAS.measurmentoptions_hint":"Usar el sistema de medida de movimiento definido por el sistema, en lugar de una línea recta (euclídeo), por defecto activado",
     "ACTIVEAURAS.measurementHeight_name":"Sistema de medida de altura",
     "ACTIVEAURAS.measurementHeight_hint":"Sistema para medir alturas con respecto a auras. Verdadero es una comparación simple, falso es distancia euclídea (experimental)",
+    "ACTIVEAURAS.debug_name" : "Debug",
+    "ACTIVEAURAS.debug_hint" : "Additional console logs for debugging steps",
     "ACTIVEAURAS.tabname": "Auras",
 
     "ACTIVEAURAS.walltoptions_name": "Paredes bloquean auras",

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
 	"title": "Active-Auras",
 	"description": "Active-Auras",
 	"author": "Kandashi",
-	"version": "0.1.34",
+	"version": "0.1.35",
 	"minimumCoreVersion": "0.7.5",
 	"compatibleCoreVersion": "0.7.9",
 	"packs": [


### PR DESCRIPTION
- Added debug setting to help with tracing errors
- Added more debug arguments throughout the code to assist in debugging
- Added check for auras in preDeleteToken before running the rest of the code
- Reworked unlinked token checks to more accuratly remove auras when disabling auras or hiding the token
- Reworked logic for removal of auras on active effect updates
- Added support for item macros when DAE supports this
- Cleaned up the code for removal of applied auras, this should prevent auras not applying/removing from tokens 
