### PR TITLE
sw5e system compatibility + fix race issue for this system

### DIFF
--- a/module.json
+++ b/module.json
@@ -40,6 +40,10 @@
             "path": "lang/ja.json"
         }
 	],
+	"systems": [
+		"dnd5e",
+		"sw5e"
+	],
 	"url": "https://github.com/kandashi/Active-Auras",
 	"manifest": "https://raw.githubusercontent.com/kandashi/Active-Auras/main/module.json",
 	"download": "https://github.com/kandashi/Active-Auras/archive/main.zip",

--- a/src/aura.js
+++ b/src/aura.js
@@ -577,7 +577,10 @@ Hooks.on("ready", () => {
                 break;
             case "character": {
                 try {
-                    tokenType = canvasToken.actor?.data.data.details.race.toLowerCase()
+                    if (game.system.data.name === "sw5e"){
+                        tokenType = canvasToken.actor?.data.data.details.species.toLowerCase();
+                    }
+                    else tokenType = canvasToken.actor?.data.data.details.race.toLowerCase();
                 } catch (error) {
                     console.error([`ActiveAuras: the token has an unreadable type`, canvasToken])
                 }
@@ -586,7 +589,12 @@ Hooks.on("ready", () => {
             case "vehicle": return;
         }
         tokenType = tokenType.replace("-", " ").split(" ");
-        let humanoidRaces = ["human", "orc", "elf", "tiefling", "gnome", "aaracokra", "dragonborn", "dwarf", "halfling", "leonin", "satyr", "genasi", "goliath", "aasimar", "bugbear", "firbolg", "goblin", "lizardfolk", "tabxi", "triton", "yuan-ti", "tortle", "changling", "kalashtar", "shifter", "warforged", "gith", "centaur", "loxodon", "minotaur", "simic hybrid", "vedalken", "verdan", "locathah", "grung"]
+        let humanoidRaces;
+        if (game.system.data.name === "sw5e"){
+            humanoidRaces = ["abyssin", "aingtii", "aleena", "anzellan", "aqualish", "arcona", "ardennian", "arkanian", "balosar", "barabel", "baragwin", "besalisk", "bith", "bothan", "cathar", "cerean", "chadrafan", "chagrian", "chevin", "chironian", "chiss", "clawdite", "codruji", "colicoid", "dashade", "defel", "devoronian", "draethos", "dug", "duros", "echani", "eshkha", "ewok", "falleen", "felucian", "fleshraider", "gamorrean", "gand", "geonosian", "givin", "gotal", "gran", "gungan", "halfhuman", "harch", "herglic", "ho’din", "human", "hutt", "iktotchi", "ithorian", "jawa", "kage", "kaleesh", "kaminoan", "karkarodon", "keldor", "killik", "klatooinian", "kubaz", "kushiban", "kyuzo", "lannik", "lasat", "lurmen", "miraluka", "mirialan", "moncalamari", "mustafarian", "muun", "nautolan", "neimoidian", "noghri", "ortolan", "patrolian", "pau’an", "pa’lowick", "pyke", "quarren", "rakata", "rattataki", "rishii", "rodian", "ryn", "selkath", "shistavanen", "sithpureblood", "squib", "ssiruu", "sullustan", "talz", "tarasin", "thisspiasian", "togorian", "togruta", "toydarian", "trandoshan", "tusken", "twi'lek", "ugnaught", "umbaran", "verpine", "voss", "vurk", "weequay", "wookie", "yevetha", "zabrak", "zeltron", "zygerrian"];
+        }
+        else humanoidRaces = ["human", "orc", "elf", "tiefling", "gnome", "aaracokra", "dragonborn", "dwarf", "halfling", "leonin", "satyr", "genasi", "goliath", "aasimar", "bugbear", "firbolg", "goblin", "lizardfolk", "tabxi", "triton", "yuan-ti", "tortle", "changling", "kalashtar", "shifter", "warforged", "gith", "centaur", "loxodon", "minotaur", "simic hybrid", "vedalken", "verdan", "locathah", "grung"];
+        
         for (x of tokenType) {
             if (humanoidRaces.includes(x)) {
                 tokenType = "humanoid"


### PR DESCRIPTION
Hello,
Add compatibility to sw5e (http://sw5e.com) by fixing a little issue regarding controls done over the type of the token.
We use "species" in SW5E instead of "race" used in dnd5e.
Add the list of humanoid species too. 

Best regards 