### PR TITLE
multiple aura tokens

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
 	"title": "Active-Auras",
 	"description": "Active-Auras",
 	"author": "Kandashi",
-	"version": "0.1.55",
+	"version": "0.1.56",
 	"minimumCoreVersion": "0.7.5",
 	"compatibleCoreVersion": "0.7.9",
 	"packs": [

--- a/src/aura.js
+++ b/src/aura.js
@@ -610,14 +610,13 @@ Hooks.on("ready", () => {
         let MapKey = canvasToken.scene._id;
         MapObject = AuraMap.get(MapKey)
         let checkEffects = MapObject.effects;
-        //Check for other types of X aura if the aura token is moved
-        if (tokenId) {
+        //Check for other types of X aura if the aura token is moved, removed due to issues with mutliple auras not updating correctly
+        /*if (tokenId) {
             checkEffects = checkEffects.filter(i => i.tokenId === tokenId)
             let duplicateEffect = []
             checkEffects.forEach(e => duplicateEffect = (MapObject.effects.filter(i => (i.data?.label === e.data?.label) && i.tokenId !== tokenId)));
             checkEffects = checkEffects.concat(duplicateEffect)
-
-        }
+        }*/
 
         for (let auraEffect of checkEffects) {
 


### PR DESCRIPTION
closes #85 
old functionality - if an aura token moved it would only check for that aura, not others to improve performance, this is now changed to a full check