### PR TITLE
0.2.11

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -52,3 +52,6 @@ Fix for Spirit Guardians spell, will need replacing and the macro importing
 
 ## 0.2.11
 Fix for non-viewed scene errors on combat advancement
+Cleaned up the range computation to make things faster
+Updated spells : Spirit Guardians, Black Tentacles, Cloudkill, Incendiary Cloud, Insect Plague, Moonbeam, Sleet Storm, 
+Any of these spells will still work with the old versions, but the new ones will remove the effect if the token is forcefully removed from the aura not on their turn

--- a/Changelog.md
+++ b/Changelog.md
@@ -49,3 +49,6 @@ Fix for Grease spell
 ## 0.2.09
 Fix for drawing effects not applying correctly
 Fix for Spirit Guardians spell, will need replacing and the macro importing
+
+## 0.2.11
+Fix for non-viewed scene errors on combat advancement

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "Active-Auras",
     "description": "Active-Auras",
     "author": "Kandashi",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "minimumCoreVersion": "0.7.5",
     "compatibleCoreVersion": "0.7.9",
     "packs": [{

--- a/src/aura.js
+++ b/src/aura.js
@@ -803,12 +803,13 @@ class ActiveAuras {
      */
     static getDistance(t1, t2, wallblocking = false, auraHeight, radius) {
         //Log("get distance callsed");
-        let xMax = t2.data.x + (radius / canvas.dimensions.distance * canvas.grid.size) + 100
-        let xMin = t2.data.x - (radius / canvas.dimensions.distance * canvas.grid.size) - 100
-        let yMax = t2.data.y + (radius / canvas.dimensions.distance * canvas.grid.size) + 100
-        let yMin = t2.data.y - (radius / canvas.dimensions.distance * canvas.grid.size) - 100
+        let { size, distance} = canvas.dimensions
+        const xMax = t2.data.x + (radius / distance * size) + t2.w  + 100
+        const xMin = t2.data.x - (radius / distance * size) - 100
+        const yMax = t2.data.y + (radius / distance * size) + t2.h + 100
+        const yMin = t2.data.y - (radius / distance * size) - 100
         if (t1.data.x < xMin || t1.data.x > xMax || t1.data.y > yMax || t1.data.y < yMin) return false;
-        var x, x1, y, y1, d, r, segments = [], rdistance, distance;
+        var x, x1, y, y1, d, r, segments = [], rdistance;
         switch (game.settings.get("ActiveAuras", "measurement",)) {
             case (true): {
                 for (x = 0; x < t1.data.width; x++) {

--- a/src/aura.js
+++ b/src/aura.js
@@ -1088,7 +1088,7 @@ class ActiveAuras {
                     if (type) {
                         if (!ActiveAuras.CheckType(canvasToken, type)) continue
                     }
-                    if (hostile && canvasToken.data._id !== game.combats.active.current.tokenId) continue;
+                    if (hostile && canvasToken.data._id !== game.combats.active?.current.tokenId) continue;
                     distance = ActiveAuras.getDistance(canvasToken, auraEntity, game.settings.get("ActiveAuras", "wall-block"), height)
                 }
                     break;
@@ -1100,7 +1100,7 @@ class ActiveAuras {
                     if (type) {
                         if (!ActiveAuras.CheckType(canvasToken, type)) continue
                     }
-                    if (hostile && canvasToken.data._id !== game.combats.active.current.tokenId) return;
+                    if (hostile && canvasToken.data._id !== game.combats.active?.current.tokenId) return;
                     if (auraEffect.casterDisposition) {
                         if (!ActiveAuras.DispositonCheck(auraTargets, auraEffect.casterDisposition, canvasToken.data.disposition)) continue;
                     }
@@ -1117,7 +1117,7 @@ class ActiveAuras {
                     if (type) {
                         if (!ActiveAuras.CheckType(canvasToken, type)) continue
                     }
-                    if (hostile && canvasToken.data._id !== game.combats.active.current.tokenId) return;
+                    if (hostile && canvasToken.data._id !== game.combats.active?.current.tokenId) return;
                     if (ActiveAuras.isPointInRegion(canvasToken.center, auraEntity.data)) distance = 0
                     else distance = false
                 }


### PR DESCRIPTION
Fix for non-viewed scene errors on combat advancement
Cleaned up the range computation to make things faster
Updated spells : Spirit Guardians, Black Tentacles, Cloudkill, Incendiary Cloud, Insect Plague, Moonbeam, Sleet Storm, 
Any of these spells will still work with the old versions, but the new ones will remove the effect if the token is forcefully removed from the aura not on their turn

