### PR TITLE
Manually refresh effect suppression

### DIFF
--- a/src/aura.js
+++ b/src/aura.js
@@ -295,6 +295,7 @@ class ActiveAuras {
         }
 
         await token.actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
+        await token.actor.applyActiveEffects();
         console.log(game.i18n.format("ACTIVEAURAS.ApplyLog", { effectDataLabel: effectData.label, tokenName: token.name }))
     }
 


### PR DESCRIPTION
Applying effects via the aura can cause them to apply as Unavailable/Suppressed


For reproduction, with Tidy5e, Active Auras, libwrapper, and DAE active. No others. Default settings on the effect. 

Dragging a target into the range of an Aura. Without opening the target, etc, if you query the target's active effects, the new effect shows as `isSuppressed: true`.




When we apply an effect via createEmbeddedDocuments, this doesn't seem to trigger the suppression determination function (`active-effects.js:25`). Since the suppression determination function `determineSuppression` isn't called immediately, in absence of something else that refreshes effects (such as opening the character sheet), this might potentially also cause some effects with other modules that query for suppression status. 




The change is based on precedence in modules such as [tidy5e](https://github.com/sdenec/tidy5e-sheet/blob/8ed3948e437a4faa8f55b1c0c9f04672ff67fa06/src/scripts/app/exhaustion.js#L146) 

