### PR TITLE
Use unspeakable methodologies to bamboozle foundry's scrolling status check

### DIFF
--- a/src/AAhelpers.js
+++ b/src/AAhelpers.js
@@ -198,9 +198,21 @@ class AAhelpers {
 
     static scrollingText(wrapped, ...args) {
         if (game.settings.get("ActiveAuras", "scrollingAura")) {
-            if (this.data.flags["ActiveAuras"]?.applied) { this.isSuppressed = true }
+          if (this.data.flags["ActiveAuras"]?.applied) {
+            Object.defineProperty(this, "isSuppressed", {
+              get: () => {
+                if (new Error('').stack.includes("ActiveEffect5e._displayScrollingStatus")){
+                    return true;
+                }
+                return this._isSuppressed;
+              },
+              set: (v) => {
+                 this._isSuppressed = v;
+              },
+            });
+          }
         }
-        return wrapped(...args)
+        return wrapped(...args);
     }
 
     static async applyTemplate(args) {


### PR DESCRIPTION
Bamboozle foundry into not showing effects.

This (ab)uses a nonstandard though plausibly semi-stable implementation detail of the stack trace. 

If this assumption fails through, it should match the original behavior. 

This is as an alternative to waiting for foundry to expose more controls for scrolling status. 