### PR TITLE
Improved "type" filter: multiple types are now supported, and fixed character race search on dnd5e

### DIFF
--- a/src/AAhelpers.js
+++ b/src/AAhelpers.js
@@ -80,7 +80,9 @@ class AAhelpers {
         }
         else humanoidRaces = ["human", "orc", "elf", "tiefling", "gnome", "aaracokra", "dragonborn", "dwarf", "halfling", "leonin", "satyr", "genasi", "goliath", "aasimar", "bugbear", "firbolg", "goblin", "lizardfolk", "tabxi", "triton", "yuan-ti", "tortle", "changling", "kalashtar", "shifter", "warforged", "gith", "centaur", "loxodon", "minotaur", "simic hybrid", "vedalken", "verdan", "locathah", "grung"];
 
-        if (tokenType.includes(type)) return true
+        let types = type.split('/');
+        const typesIntersection = tokenType.filter(t => types.includes(t));
+        if (typesIntersection.length > 0) return true
 
         for (let x of tokenType) {
             if (humanoidRaces.includes(x)) {

--- a/src/AAhelpers.js
+++ b/src/AAhelpers.js
@@ -66,7 +66,7 @@ class AAhelpers {
                     if (game.system.data.name === "sw5e") {
                         tokenType = canvasToken.actor?.data.data.details.species.toLowerCase();
                     }
-                    else tokenType = [canvasToken.actor?.data.data.details.race.toLowerCase().replace("-", " ").split(" ")];
+                    else tokenType = canvasToken.actor?.data.data.details.race.toLowerCase().replace("-", " ").split(" ");
                 } catch (error) {
                     console.error([`ActiveAuras: the token has an unreadable type`, canvasToken])
                 }


### PR DESCRIPTION
Hi,

I took the liberty to implement multiple types support. While testing it, I discovered that race of a dnd5e PC generates nested arrays due to additional [] wrapping a split call. Given that other discovery methods generates one dimensional arrays, it seemed like a simple typo.
Feel free to reject and I'll remove this "fix", and adjust the multi-type support accordingly.

Thanks