### PR TITLE
Standardize on debounceCollate to help with state oscillation

### DIFF
--- a/src/AAhelpers.js
+++ b/src/AAhelpers.js
@@ -161,8 +161,11 @@ class AAhelpers {
             if (removeToken?.actor?.effects.size > 0) {
                 for (let testEffect of removeToken.actor.effects) {
                     if (!EffectsArray.includes(testEffect.data.origin) && testEffect.data?.flags?.ActiveAuras?.applied) {
-                        await removeToken.actor.deleteEmbeddedDocuments("ActiveEffect", [testEffect.id])
-                        console.log(game.i18n.format("ACTIVEAURAS.RemoveLog", { effectDataLabel: testEffect.data.label, tokenName: removeToken.name }))
+                        try {
+                            await removeToken.actor.deleteEmbeddedDocuments("ActiveEffect", [testEffect.id]);
+                        } finally {
+                            console.log(game.i18n.format("ACTIVEAURAS.RemoveLog", { effectDataLabel: testEffect.data.label, tokenName: removeToken.name }));
+                        }
                     }
                 }
             }
@@ -171,9 +174,12 @@ class AAhelpers {
     static async RemoveAllAppliedAuras() {
         for (let removeToken of canvas.tokens.placeables) {
             if (removeToken?.actor?.effects.size > 0) {
-                let effects = removeToken.actor.effects.reduce((a, v) => { if (v.data?.flags?.ActiveAuras?.applied) return a.concat(v.id) }, [])
-                await removeToken.actor.deleteEmbeddedDocuments("ActiveEffect", effects)
-                console.log(game.i18n.format("ACTIVEAURAS.RemoveLog", { tokenName: removeToken.name }))
+                let effects = removeToken.actor.effects.reduce((a, v) => { if (v.data?.flags?.ActiveAuras?.applied) return a.concat(v.id) }, []);
+                try {
+                    await removeToken.actor.deleteEmbeddedDocuments("ActiveEffect", effects);
+                } finally {
+                    console.log(game.i18n.format("ACTIVEAURAS.RemoveLog", { tokenName: removeToken.name }));
+                }
             }
         }
 

--- a/src/aura.js
+++ b/src/aura.js
@@ -300,17 +300,18 @@ class ActiveAuras {
     }
 
     /**
-     * 
-     * @param {Token} token - token instance to remove effect from
+     * @param {String} tokenID - token instance to remove effect from
      * @param {String} effectOrigin - origin of effect to remove
      */
     static async RemoveActiveEffects(tokenID, effectOrigin) {
-        const token = canvas.tokens.get(tokenID)
+        const token = canvas.tokens.get(tokenID);
         for (const tokenEffects of token.actor.effects) {
             if (tokenEffects.data.origin === effectOrigin && tokenEffects.data.flags?.ActiveAuras?.applied === true) {
-                await token.actor.deleteEmbeddedDocuments("ActiveEffect", [tokenEffects.id])
-                console.log(game.i18n.format("ACTIVEAURAS.RemoveLog", { effectDataLabel: effectOrigin, tokenName: token.name }))
-
+                try {
+                    await token.actor.deleteEmbeddedDocuments("ActiveEffect", [tokenEffects.id]);
+                } finally {
+                    console.log(game.i18n.format("ACTIVEAURAS.RemoveLog", { effectDataLabel: effectOrigin, tokenName: token.name }));
+                }
             }
         }
     }


### PR DESCRIPTION
After some debugging, the underlying cause seems to be we're trying to remove the effect before its actually added. I'm pretty sure the change to `updateToken` hook is what actually fixed this. The try-finally around the actual `deleteEmbeddedDocuments()` just helped with troubleshooting what was being removed. I don't know that it needs to be retained, but I don't think it hurts anything.

Finally I fixed a handful or warnings in my IDE around missing `;`'s.
