### PR TITLE
SWADE fix for v10

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -102,3 +102,11 @@ Some template auras would fail.
 # 0.4.24
 
 Handle cases of multiple GM's logged in.
+
+# 0.5.0
+
+Official v10 Release
+
+# 0.5.1
+
+Would not work in SWADE due to a 5e assumption in the template shape detection algorithm.

--- a/module.json
+++ b/module.json
@@ -8,7 +8,7 @@
   "url": "https://github.com/kandashi/Active-Auras",
   "bugs": "https://github.com/kandashi/Active-Auras/issues",
   "flags": {},
-  "version": "0.5.0",
+  "version": "0.5.1",
   "compatibility": {
     "minimum": 10,
     "verified": 10

--- a/src/AAhelpers.js
+++ b/src/AAhelpers.js
@@ -128,18 +128,18 @@ class AAhelpers {
 
     static HPCheck(entity) {
         let actor = entity.actor;
-        if(entity.collectionName === "actors") actor = entity;
+        if (entity.collectionName === "actors") actor = entity;
         switch (game.system.id) {
             case "dnd5e": ;
             case "sw5e": {
-                if (getProperty(actor, "system.attributes.hp.max") === 0) return true;
+                if (getProperty(actor, "system.attributes.hp.max") === 0) return true; // dead
                 if (getProperty(actor, "system.attributes.hp.value") <= 0) return false;
-                else return true;
+                else return true; // dead
             }
             case "swade": {
                 let { max, value, ignored } = actor.system.wounds;
                 if (value - ignored >= max) return false;
-                else return true;
+                else return true; // dead
             }
         }
     }

--- a/src/aura.js
+++ b/src/aura.js
@@ -13,9 +13,11 @@ class ActiveAuras {
     static async MainAura(movedToken, source, sceneID) {
         let perfStart;
         let perfEnd;
-        if (AAdebug) { perfStart = performance.now() }
+        if (AAdebug) { 
+            perfStart = performance.now();
+            console.log("MainAura Params", { movedToken, source, sceneID});
+        }
         if (typeof movedToken?.documentName !== "string") movedToken = movedToken?.document ?? undefined;
-        if (AAdebug) { console.log(source) }
         if (!AAgm) return;
         const sceneCombat = game.combats.filter(c => c.scene?.id === sceneID);
         if (game.settings.get("ActiveAuras", "combatOnly") && !sceneCombat[0]?.started) {
@@ -49,7 +51,7 @@ class ActiveAuras {
             const MapKey = mapEffect[0];
             map.set(MapKey, { add: mapEffect[1].add, token: mapEffect[1].token, effect: mapEffect[1].effect.data });
         }
-        if (AAdebug) console.log(map)
+        if (AAdebug) console.log("Active Aura Effect map", map);
 
         map.forEach(compareMap);
 
@@ -106,6 +108,7 @@ class ActiveAuras {
          */
     static UpdateAllTokens(map, tokens, tokenId) {
         for (const canvasToken of tokens) {
+            // if (AAdebug) console.log("Updating canvas token", {canvasToken, tokenId});
             ActiveAuras.UpdateToken(map, canvasToken, tokenId);
         }
         return map;
@@ -140,12 +143,13 @@ class ActiveAuras {
             checkEffects = checkEffects.concat(duplicateEffect);
         }
 
+        // if (AAdebug) console.log("ActiveAura UpdateToken Map details", { MapKey, MapObject, checkEffects, tokenAlignment})
+
         for (const auraEffect of checkEffects) {
             const auraTargets = auraEffect.data.flags?.ActiveAuras?.aura;
 
             const { radius, height, hostile, wildcard, extra } = auraEffect.data.flags?.ActiveAuras;
             let { type, alignment } = auraEffect.data.flags?.ActiveAuras;
-            const { parentActorLink, parentActorId } = auraEffect;
             type = type !== undefined ? type.toLowerCase() : "";
             alignment = alignment !== undefined ? alignment.toLowerCase() : "";
             if (alignment && !tokenAlignment.includes(alignment) && !tokenAlignment.includes("any")) continue; // cleaned up alignment check and moved here. 
@@ -156,13 +160,12 @@ class ActiveAuras {
             let auraAlignment = auraEffect.data.flags?.ActiveAuras?.alignment !== undefined ? auraEffect.data.flags?.ActiveAuras?.alignment.toLowerCase() : "";
             let hostileTurn = auraEffect.data.flags?.ActiveAuras?.hostile
             */
-            const auraEntityType = auraEffect.entityType;
 
-            switch (auraEntityType) {
+            switch (auraEffect.entityType) {
                 //{data: testEffect.data, parentActorLink :testEffect.parent.data.token.actorLink, parentActorId : testEffect.parent._id, tokenId: testToken.id, templateId: template._id, }
                 case "token": {
-                    if (parentActorLink) {
-                        const auraTokenArray = game.actors.get(parentActorId).getActiveTokens();
+                    if (auraEffect.parentActorLink) {
+                        const auraTokenArray = game.actors.get(auraEffect.parentActorId).getActiveTokens();
                         if (auraTokenArray.length > 1) {
                             auraEntity = auraTokenArray[0];
                             console.error("AA: Duplicate Linked Tokens detected, defaulting to first token.");

--- a/src/collateAuras.js
+++ b/src/collateAuras.js
@@ -21,7 +21,7 @@ async function CollateAuras(sceneID, checkAuras, removeAuras, source) {
         if (testToken.flags["multilevel-tokens"]) continue;
         // applying auras on dead?
         if (!AAhelpers.HPCheck(testToken) && game.settings.get("ActiveAuras", "dead-aura")) {
-            if (AAdebug) console.log(`Skipping ${testToken.name}, 0hp`);
+            if (AAdebug) console.log(`Skipping ${testToken.name}, "DEAD/0hp"`);
             continue;
         }
         // applying auras on hidden?

--- a/src/templateDetection.js
+++ b/src/templateDetection.js
@@ -20,47 +20,54 @@ function getTemplateShape(template) {
             break;
         case "ray":
             shape = template._getRayShape( direction, distance, width);
+            break;
     }
-    shape.x = template.x
-    shape.y = template.y
-    return shape
+    shape.x = template.x;
+    shape.y = template.y;
+    return shape;
 }
 
 function getAuraShape(source, radius) {
-    const gs = canvas.dimensions.size
-    const gd = gs / canvas.dimensions.distance
-    if(game.settings.get(game.system.id, "diagonalMovement") === "555") return new PIXI.Rectangle(
-        source.x - (radius * gd),
-        source.y - (radius * gd),
-        (radius * gd)*2 + source.document.width *gs,
-        (radius * gd)*2 + source.document.height *gs,
-    ) 
-    return new PIXI.Circle(source.center.x, source.center.y, ((radius * gd) + (source.document.width / 2 * gs)))
+    const gs = canvas.dimensions.size;
+    const gd = gs / canvas.dimensions.distance;
+    if (["dnd5e"].includes(game.system.id) && game.settings.get(game.system.id, "diagonalMovement") === "555") {
+        return new PIXI.Rectangle(
+            source.x - (radius * gd),
+            source.y - (radius * gd),
+            (radius * gd)*2 + source.document.width *gs,
+            (radius * gd)*2 + source.document.height *gs,
+        );
+    } 
+    return new PIXI.Circle(source.center.x, source.center.y, ((radius * gd) + (source.document.width / 2 * gs)));
 }
 
 function PixiFromPolygon(data) {
-    let pixiPoints = data.points.map(p => new PIXI.Point(p[0] + data.x, p[1] + data.y))
-    return new PIXI.Polygon(pixiPoints)
+    const pixiPoints = data.points.map(p => new PIXI.Point(p[0] + data.x, p[1] + data.y));
+    return new PIXI.Polygon(pixiPoints);
 }
 
 function PixiFromEllipse(data) {
-    let { x, y, width, height } = data
+    const { x, y, width, height } = data
     return new PIXI.Ellipse(x + width / 2, y + height / 2, width / 2, height / 2)
 }
 
 function PixiFromRect(data) {
-    let { x, y, width, height } = data
+    const { x, y, width, height } = data
     return new PIXI.Rectangle(x, y, width, height)
 }
 
 function getDrawingShape(data) {
     let shape;
     switch (data.type) {
-        case CONST.DRAWING_TYPES.RECTANGLE : shape = PixiFromRect(data);
-        break;
-        case CONST.DRAWING_TYPES.ELLIPSE : shape = PixiFromEllipse(data);
-        break;
-        case CONST.DRAWING_TYPES.POLYGON : shape = PixiFromPolygon(data)
+        case CONST.DRAWING_TYPES.RECTANGLE: 
+            shape = PixiFromRect(data);
+            break;
+        case CONST.DRAWING_TYPES.ELLIPSE:
+            shape = PixiFromEllipse(data);
+            break;
+        case CONST.DRAWING_TYPES.POLYGON:
+            shape = PixiFromPolygon(data);
+            break;
     }
-    return shape
+    return shape;
 }


### PR DESCRIPTION
`getAuraShape` assumed a system setting called `diagonalMovement` that exists in 5e only.