### PR TITLE
Reduce times up expire

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -122,3 +122,7 @@ Correct a missing deprecated data reference.
 Try and prevent the double effect deletion.
 HP Check could misfire effect application due to bad HP logic.
 Auras in 5e will support the `isSuppressed` flag, and triggered by attunement and equipped status if it's an item. (@DarkByteZero)
+
+# 0.5.4
+
+Don't trigger effect removal when times-up expires an effect as it cleans up for us.

--- a/module.json
+++ b/module.json
@@ -8,7 +8,7 @@
   "url": "https://github.com/kandashi/Active-Auras",
   "bugs": "https://github.com/kandashi/Active-Auras/issues",
   "flags": {},
-  "version": "0.5.3",
+  "version": "0.5.4",
   "compatibility": {
     "minimum": 10,
     "verified": 10

--- a/src/AAhooks.js
+++ b/src/AAhooks.js
@@ -183,10 +183,12 @@ Hooks.on("updateActiveEffect", (effect, _update) => {
 Hooks.on("deleteActiveEffect", (effect, options) => {
     if (canvas.scene === null) { if (AAdebug) { console.log("Active Auras disabled due to no canvas") } return }
     if (!AAgm) return;
-    let applyStatus = effect.flags?.ActiveAuras?.applied;
-    let auraStatus = effect.flags?.ActiveAuras?.isAura;
-    if (!applyStatus && auraStatus) {
-        if (AAdebug) console.log("deleteActiveEffect, collate auras true false", { effect, update: options });
+    const applyStatus = effect.flags?.ActiveAuras?.applied;
+    const auraStatus = effect.flags?.ActiveAuras?.isAura;
+    const timeUpExpiry = options["expiry-reason"]?.startsWith("times-up:");
+
+    if (!applyStatus && auraStatus && !timeUpExpiry) {
+        if (AAdebug) console.log("deleteActiveEffect, collate auras true false", { effect, options });
         debouncedCollate(canvas.scene.id, false, true, "deleteActiveEffect");
     }
 });


### PR DESCRIPTION
Times-up would expire an effect and delete it, check for the times up expiry flag and don't delete if present, as times up will already delete it. Resolves #254 