### PR TITLE
D&D 4e Compatibility

### DIFF
--- a/src/AAhelpers.js
+++ b/src/AAhelpers.js
@@ -46,6 +46,8 @@ class AAhelpers {
     static CheckType(canvasToken, type) {
         switch (game.system.id) {
             case ("dnd5e"):
+            case ("dnd4e"):
+                return AAhelpers.typeCheck4e(canvasToken, type);
             case ("sw5e"):
                 return AAhelpers.typeCheck5e(canvasToken, type);
             case ("swade"):
@@ -118,6 +120,33 @@ class AAhelpers {
             case "vehicle": return;
         }
         return tokenType === type;
+    }
+
+    static typeCheck4e(canvasToken, type) {
+        let tokenType;
+        switch (canvasToken.actor.type) {
+            case "NPC": {
+                try {
+                    tokenType = [canvasToken.actor?.system.details.type, canvasToken.actor?.system.details.other, canvasToken.actor?.system.details.origin];
+                } catch (error) {
+                    console.error([`ActiveAuras: the token has an unreadable type`, canvasToken]);
+                }
+            }
+                break;
+            case "Player Character": {
+                try {
+                    tokenType = ["humanoid"]; //Will update this later after adding detailed info to PCs
+                } catch (error) {
+                    console.error([`ActiveAuras: the token has an unreadable type`, canvasToken]);
+                }
+            }
+                break;
+            case "group":
+            case "vehicle":
+                return;
+        };
+        if (tokenType.includes(type)) return true;
+        return false;
     }
 
     static Wildcard(canvasToken, wildcard, extra) {

--- a/src/AAhelpers.js
+++ b/src/AAhelpers.js
@@ -46,12 +46,12 @@ class AAhelpers {
     static CheckType(canvasToken, type) {
         switch (game.system.id) {
             case ("dnd5e"):
-            case ("dnd4e"):
-                return AAhelpers.typeCheck4e(canvasToken, type);
             case ("sw5e"):
                 return AAhelpers.typeCheck5e(canvasToken, type);
             case ("swade"):
-                return AAhelpers.typeCheckSWADE(canvasToken, type);
+                return AAhelpers.typeCheckSWADE(canvasToken, type);                
+            case ("dnd4e"):
+                return AAhelpers.typeCheck4e(canvasToken, type);
         }
     }
     static typeCheck5e(canvasToken, type) {

--- a/src/templateDetection.js
+++ b/src/templateDetection.js
@@ -30,7 +30,7 @@ function getTemplateShape(template) {
 function getAuraShape(source, radius) {
     const gs = canvas.dimensions.size;
     const gd = gs / canvas.dimensions.distance;
-    if (["dnd5e"].includes(game.system.id) && game.settings.get(game.system.id, "diagonalMovement") === "555") {
+    if (["dnd5e","dnd4e"].includes(game.system.id) && game.settings.get(game.system.id, "diagonalMovement") === "555") {
         return new PIXI.Rectangle(
             source.x - (radius * gd),
             source.y - (radius * gd),


### PR DESCRIPTION
Hiya, I hope you don't mind but I took the liberty of adding some code to improve Active Auras' compatibility with D&D 4e (there are _dozens_ of us! :p). Since the 4e Foundry implementation is built using 5e as a base, AA functions quite well out of the box, but there are some specifics that benefited from additional tweaks. Specifically, I've added 4e to the lists of systems to check for non-Euclidean diagonals as is its default, and I've added a 4e-specific type check function to let us apply auras based on creature origin, type and subtype.