### PR TITLE
For Template auras the check for canvasToken.disposition returns undefined.

### DIFF
--- a/src/lib/ActiveAuras.mjs
+++ b/src/lib/ActiveAuras.mjs
@@ -195,7 +195,7 @@ export class ActiveAuras {
             if (type && !AAHelpers.CheckType(canvasToken, type)) continue;
             if (hostile && canvasToken.id !== game.combats.active.current.tokenId) return;
             if (auraEffect.casterDisposition) {
-              if (!AAHelpers.DispositionCheck(auraTargets, auraEffect.casterDisposition, canvasToken.disposition))
+              if (!AAHelpers.DispositionCheck(auraTargets, auraEffect.casterDisposition, canvasToken.document.disposition))
                 continue;
             }
             // const shape = AATemplates.getTemplateShape(auraEntity);


### PR DESCRIPTION
Closes: https://github.com/kandashi/Active-Auras/issues/293

disposition is a `Token5e#Document` property