### PR TITLE
Remove unknown property lookup

### DIFF
--- a/src/lib/AATemplates.js
+++ b/src/lib/AATemplates.js
@@ -29,7 +29,7 @@ export class AATemplates {
 
   static getAuraShape(source, radius) {
     let shape = "circle";
-    if (["dnd5e", "dnd4e"].includes(game.system.id)) {
+    if (["dnd4e"].includes(game.system.id)) {
       if (foundry.utils.isNewerVersion(game.version, "12.0") && foundry.utils.isNewerVersion(game.system.version, "3.3.0")) {
         if (game.settings.get("core", "gridDiagonals") === 0) shape = "rectangle";
       } else {


### PR DESCRIPTION
Was performing a lookup on dnd5e.diagonalmovement, which is unknown. Causing auras to not properly apply to allies within range on auras with radius